### PR TITLE
remove clobber option from constructor (Issue #77)

### DIFF
--- a/ledger.py
+++ b/ledger.py
@@ -185,7 +185,7 @@ class Ledger:
         self.element_ledger.write_variables(self.ex.data)
 
     def a_write(self, path):
-        out = nc.Dataset(path, "w", True, format="NETCDF4")
+        out = nc.Dataset(path, "w", clobber=False, format="NETCDF4")
         old = self.ex.data
 
         out.setncatts(old.__dict__)

--- a/test_exodus.py
+++ b/test_exodus.py
@@ -469,7 +469,7 @@ def test_remove_duplicate_nodes(tmpdir):
 
 
 def test_basic_ns_append(tmpdir):
-    exofile = Exodus('sample-files/can.ex2', 'a', clobber=False)
+    exofile = Exodus('sample-files/can.ex2', 'a')
     exofile.add_nodeset([1, 2, 3, 4, 5], 10)
 
     with pytest.raises(AttributeError):
@@ -479,7 +479,7 @@ def test_basic_ns_append(tmpdir):
     exofile.close()
 
     exofile = Exodus(str(tmpdir) + '\\test.ex2', 'r')
-    original = Exodus('sample-files/can.ex2', 'r', clobber=False)
+    original = Exodus('sample-files/can.ex2', 'r')
 
     print("\n", exofile.data.dimensions['num_node_sets'])
 


### PR DESCRIPTION
Clobber option removed from constructor. Per Sandia specifications, files should never be overwritten by the library. By removing to clobber option entirely, we can hardcode the library to always initialize the netCDF4 dataset with clobber=False. 

Low Priority pull request