### PR TITLE
Use internal IDs in split_side_set + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Michael Coppeta, Christoffer Rokholm, Allen Santmier, Christopher Turko, John Wa
 - Selector objects could potentially be used in read functions, but there is currently no support.
 - `output_subset` will not output data it does not recognize (things like assemblies won’t be carried over).
 - The library doesn’t cache function results, so repeat identical function calls are slower than they could be if caching was used.
-- `split_sideset` has known bugs (see behavior with `bake.e` sample file) and somewhat restricted functionality including a lack of support for side set variables. Coordinate-based side set splitting functions are also prone to bugs due to limited testing at time of release.
+- `split_sideset` has somewhat restricted functionality, including a lack of support for side set variables, but is provided as a model for how users can create their own functions for splitting side sets. Coordinate-based side set splitting functions are also prone to bugs due to limited testing at time of release.
 - Skinning has two main issues. First, the algorithm for eliminating duplicate faces will remove front/back faces because they share the same nodes. Second, it’s not clear whether TRI refers to triangle blocks or trishell blocks. The `skin` function currently takes a parameter so that it may be specified.  
 - Elemental attributes are not handled in a/w modes. If elements are changed in append mode, then attributes may not be retained correctly. 
 

--- a/exodusutils/ss_ledger.py
+++ b/exodusutils/ss_ledger.py
@@ -314,7 +314,6 @@ class SSLedger:
     # User function should return boolean and take in tuple of (element, side).
     # Function provided here as a model for users to add other split_sideset functions
     # to library with more varied functionality
-    # TODO: known bug with bake.e sample file
     # TODO: handle sideset variables
     def split_sideset(self, old_ss, function, ss_id1, ss_id2, delete, ss_name1, ss_name2):
         # Get sideset that will be split
@@ -331,21 +330,24 @@ class SSLedger:
 
         num_df_per_side = int(self.num_dist_fact[ndx] / self.ss_sizes[ndx]) # find number of df per side, if 0 there are no df
 
-        meet_criteria_elem = []
-        meet_criteria_side = []
-        meet_criteria_df = []
-        not_met_elem = []
-        not_met_side = []
-        not_met_df = []
-        for i in range(self.ss_sizes[ndx]):
-            side_tuple = (self.ss_elem[ndx][i], self.ss_sides[ndx][i])
-            if function(side_tuple):
+        elem_id_map = self.ex.get_elem_id_map() # get internal elem IDs
+
+        meet_criteria_elem = [] # will contain elements that make function True
+        meet_criteria_side = [] # will contain faces of elements that make function True
+        meet_criteria_df = [] # will contain dsit. fact. of sides that make function True
+        not_met_elem = [] # will contain elements that make function False
+        not_met_side = [] # will contain faces of elements that make function False
+        not_met_df = [] # will contain dsit. fact. of sides that make function False
+
+        for i in range(self.ss_sizes[ndx]): # iterate through sides
+            side_tuple = (elem_id_map[self.ss_elem[ndx][i] - 1], self.ss_sides[ndx][i]) # (element, face) tuple
+            if function(side_tuple): # if side makes user-specified function evaluate to True
                 meet_criteria_elem.append(side_tuple[0])
                 meet_criteria_side.append(side_tuple[1])
                 adjusted_i = i * num_df_per_side # adjust i to account for multiple df
                 if (num_df_per_side != 0):
                     meet_criteria_df.extend(range(adjusted_i,  adjusted_i + num_df_per_side))
-            else:
+            else: # if side makes user-specified function evaluate to False
                 not_met_elem.append(side_tuple[0])
                 not_met_side.append(side_tuple[1])
                 adjusted_i = i * num_df_per_side # adjust i to account for multiple df
@@ -375,7 +377,7 @@ class SSLedger:
            self.remove_sideset(old_ss)
 
     # Creates 2 new sidesets from sides in old sideset based on x-coordinate values.
-    # TODO: Test function more thoroughly, most testing informal and only on 'cube_its_mod.e' sample file
+    # TODO: Test function more thoroughly, most testing done informally
     def split_sideset_x_coords(self, old_ss, comparison, x_value, all_nodes, ss_id1, ss_id2, delete, ss_name1, ss_name2):
         # Set comparison that will be used
         if comparison == '<':
@@ -492,7 +494,7 @@ class SSLedger:
            self.remove_sideset(old_ss)
 
     # Creates 2 new sidesets from sides in old sideset based on y-coordinate values.
-    # TODO: Test function more thoroughly, most testing informal and only on 'cube_its_mod.e' sample file
+    # TODO: Test function more thoroughly, most testing done informally
     def split_sideset_y_coords(self, old_ss, comparison, y_value, all_nodes, ss_id1, ss_id2, delete, ss_name1, ss_name2):
         # Set comparison that will be used
         if comparison == '<':
@@ -520,7 +522,7 @@ class SSLedger:
             sides = ss[1]
             self.ss_elem[ndx] = np.array(elems)
             self.ss_sides[ndx] = np.array(sides)
-            self.ss_dist_fact[ndx] = np.array(self.ex.get_side_set_df(old_ss))
+            self.ss_dist_fact[ndx] = np.array(self.get_side_set_df(old_ss))
             # for i in range(self.num_ss_var):
             #     if i == 0:
             #         self.ss_vars[ndx] = []
@@ -608,7 +610,7 @@ class SSLedger:
            self.remove_sideset(old_ss)
 
     # Creates 2 new sidesets from sides in old sideset based on z-coordinate values.
-    # TODO: Test function more thoroughly, most testing informal and only on 'cube_its_mod.e' sample file
+    # TODO: Test function more thoroughly, most testing done informally
     def split_sideset_z_coords(self, old_ss, comparison, z_value, all_nodes, ss_id1, ss_id2, delete, ss_name1, ss_name2):
         # Set comparison that will be used
         if comparison == '<':
@@ -637,7 +639,7 @@ class SSLedger:
             sides = ss[1]
             self.ss_elem[ndx] = np.array(elems)
             self.ss_sides[ndx] = np.array(sides)
-            self.ss_dist_fact[ndx] = np.array(self.ex.get_side_set_df(old_ss))
+            self.ss_dist_fact[ndx] = np.array(self.get_side_set_df(old_ss))
             # for i in range(self.num_ss_var):
             #     if i == 0:
             #         self.ss_vars[ndx] = []

--- a/exodusutils/ss_ledger.py
+++ b/exodusutils/ss_ledger.py
@@ -334,10 +334,10 @@ class SSLedger:
 
         meet_criteria_elem = [] # will contain elements that make function True
         meet_criteria_side = [] # will contain faces of elements that make function True
-        meet_criteria_df = [] # will contain dsit. fact. of sides that make function True
+        meet_criteria_df = [] # will contain dist. fact. of sides that make function True
         not_met_elem = [] # will contain elements that make function False
         not_met_side = [] # will contain faces of elements that make function False
-        not_met_df = [] # will contain dsit. fact. of sides that make function False
+        not_met_df = [] # will contain dist. fact. of sides that make function False
 
         for i in range(self.ss_sizes[ndx]): # iterate through sides
             side_tuple = (elem_id_map[self.ss_elem[ndx][i] - 1], self.ss_sides[ndx][i]) # (element, face) tuple


### PR DESCRIPTION
Applies fix from coordinate-based side set splitting functions to basic split_side_set function. Also minor changes to coordinate-based functions and some documentation changes.